### PR TITLE
Add support for partial reads and response headers with trailers

### DIFF
--- a/internal/app/framereader/framereader.go
+++ b/internal/app/framereader/framereader.go
@@ -42,6 +42,7 @@ func (frameReader *FrameReader) Read(packet *models.Packet) (models.RenderModel,
 	switch frame := frame.(type) {
 	case *http2.MetaHeadersFrame:
 		metaHeaders := make(map[string]string)
+		isTrailer := false
 		for _, hf := range frame.Fields {
 			metaHeaders[hf.Name] = hf.Value
 			if hf.Name == ":path" {
@@ -71,11 +72,21 @@ func (frameReader *FrameReader) Read(packet *models.Packet) (models.RenderModel,
 					connKey,
 					stream,
 				)
+			} else if hf.Name == "grpc-status" {
+				stream, _ = frameReader.Streams.Get(connKey, streamID)
+				isTrailer = true
 			}
 		}
 
 		if stream != nil {
-			stream.MetaHeaders = metaHeaders
+			if isTrailer {
+				for key, value := range metaHeaders {
+					stream.MetaHeaders[key] = value
+				}
+				return models.NewHttp2Response(packet, stream, stream.ResponseGrpcMessage), nil
+			} else {
+				stream.MetaHeaders = metaHeaders
+			}
 		}
 	case *http2.DataFrame:
 
@@ -86,15 +97,12 @@ func (frameReader *FrameReader) Read(packet *models.Packet) (models.RenderModel,
 			return nil, err
 		}
 
-		var http2Model models.RenderModel
 		switch stream.Type {
 		case models.RequestType:
-			http2Model = models.NewHttp2Request(packet, stream, grpcMessage)
+			return models.NewHttp2Request(packet, stream, grpcMessage), nil
 		case models.ResponseType:
-			http2Model = models.NewHttp2Response(packet, stream, grpcMessage)
+			stream.ResponseGrpcMessage = grpcMessage
 		}
-
-		return http2Model, nil
 	}
 
 	return nil, nil

--- a/internal/app/framereader/framereader.go
+++ b/internal/app/framereader/framereader.go
@@ -81,7 +81,7 @@ func (frameReader *FrameReader) Read(packet *models.Packet) (models.RenderModel,
 
 		stream, _ := frameReader.Streams.Get(connKey, streamID)
 
-		grpcMessage, err := grpc.Decode(stream.Path, frame, stream.Type)
+		grpcMessage, err := grpc.Decode(stream.Path, frame, stream.Type, &stream.GrpcState)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/app/models/stream.go
+++ b/internal/app/models/stream.go
@@ -13,4 +13,10 @@ type Stream struct {
 	MetaHeaders map[string]string
 	Path        string
 	Type        int
+	GrpcState   GrpcState
+}
+
+type GrpcState struct {
+	IsPartialRead bool
+	Buf           []byte
 }

--- a/internal/app/models/stream.go
+++ b/internal/app/models/stream.go
@@ -9,11 +9,12 @@ const (
 
 //Stream ...
 type Stream struct {
-	ID          uint32
-	MetaHeaders map[string]string
-	Path        string
-	Type        int
-	GrpcState   GrpcState
+	ID                  uint32
+	MetaHeaders         map[string]string
+	Path                string
+	Type                int
+	GrpcState           GrpcState
+	ResponseGrpcMessage interface{}
 }
 
 type GrpcState struct {


### PR DESCRIPTION
First I want to thank you for this amazing project. It really helped me with debugging some services.

I've added some improvements. If you only want to merge some of them I can open separate PRs.

Some clients (C#) send the message length in a separate HTTP2 frame.

```
&http2.DataFrame{FrameHeader:http2.FrameHeader{valid:true, Type:0x0, Flags:0x0, Length:0x5, StreamID:0x1}, data:[]uint8{0x0, 0x0, 0x0, 0x1, 0xc2}}
&http2.DataFrame{FrameHeader:http2.FrameHeader{valid:true, Type:0x0, Flags:0x0, Length:0x1c2, StreamID:0x1}, data:[]uint8{...}}
```

Response headers are also useful for debugging. Error messages are reported in HTTP2 trailer meta headers frame so trailer headers are added to the response headers and response is reported after trailers are processed.

```
map[
  :status:200
  accept-encoding:identity,gzip
  content-type:application/grpc
  grpc-accept-encoding:identity,deflate,gzip
  grpc-message:('My error message',)
  grpc-status:9
]
```